### PR TITLE
refactor: isolate package installation task

### DIFF
--- a/local.yml
+++ b/local.yml
@@ -10,29 +10,8 @@
       changed_when: False
 
   tasks:
-  - include: tasks/gnome.yml    
-  - name: install packages
-    package:
-      name:
-        - btop
-        - python3-psutil
-        - starship
-        - zoxide
-        - micro
-        - fastfetch
-        - tldr
-        - clamav
-        - rclone
-        - vlc
-        - drawing 
-        - libreoffice 
-        - firefox
-        - chrome-gnome-shell
-        - slack
-        - xournalpp
-      state: latest
-      update_cache: yes
-    when: ansible_distribution in ["Debian", "Ubuntu"]
+  - import_tasks: tasks/gnome.yml
+  - import_tasks: tasks/packages.yml
 
   - name: copy .bashrc file
     copy:

--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -1,0 +1,23 @@
+- name: install packages
+  package:
+    name:
+      - btop
+      - python3-psutil
+      - starship
+      - zoxide
+      - micro
+      - fastfetch
+      - tldr
+      - clamav
+      - rclone
+      - vlc
+      - drawing
+      - libreoffice
+      - firefox
+      - chrome-gnome-shell
+      - slack
+      - xournalpp
+    state: latest
+    update_cache: yes
+  when: ansible_distribution in ["Debian", "Ubuntu"]
+


### PR DESCRIPTION
## Summary
- include packages tasks from a separate file
- add dedicated tasks/packages.yml with package list
- switch to `import_tasks` when referencing task files

## Testing
- `ansible-playbook --syntax-check local.yml`


------
https://chatgpt.com/codex/tasks/task_b_688df5ec19448333a879d939ed6c5f57