### PR TITLE
refactor: extract ansible user tasks

### DIFF
--- a/local.yml
+++ b/local.yml
@@ -6,36 +6,26 @@
   pre_tasks:
     - name: update repositories
       apt:
-        update_cache: yes
-      changed_when: False
+        update_cache: true
+      changed_when: false
 
   tasks:
-  - import_tasks: tasks/gnome.yml
-  - import_tasks: tasks/packages.yml
+    - import_tasks: tasks/gnome.yml
+    - import_tasks: tasks/packages.yml
 
-  - name: copy .bashrc file
-    copy:
-     src: files/bashrc
-     dest: /home/lion/.bashrc
-     owner: lion
-     group: lion
+    - name: copy .bashrc file
+      copy:
+        src: files/bashrc
+        dest: /home/lion/.bashrc
+        owner: lion
+        group: lion
 
-  - name: add ansible user
-    user:
-      name: velociraptor
-      system: yes
+    - import_tasks: tasks/ansible_user.yml
 
-  - name: set up sudo for ansible user
-    copy:
-      src: files/sudoer_velociraptor
-      dest: /etc/sudoers.d/velociraptor
-      owner: root
-      group: root
-      mode: 0440
-
-  - name: add ansible-pull cron job
-    cron:
-      name: ansible auto-provision
-      user: velociraptor
-      minute: "*/10"
-      job: ansible-pull -o -U https://github.com/djspatule/ansible-autoconfig.git
+    - name: add ansible-pull cron job
+      cron:
+        name: ansible auto-provision
+        user: velociraptor
+        minute: "*/10"
+        job: >-
+          ansible-pull -o -U https://github.com/djspatule/ansible-autoconfig.git

--- a/tasks/ansible_user.yml
+++ b/tasks/ansible_user.yml
@@ -1,0 +1,13 @@
+---
+- name: add ansible user
+  user:
+    name: velociraptor
+    system: true
+
+- name: set up sudo for ansible user
+  copy:
+    src: files/sudoer_velociraptor
+    dest: /etc/sudoers.d/velociraptor
+    owner: root
+    group: root
+    mode: 0440


### PR DESCRIPTION
## Summary
- move ansible user creation and sudo setup tasks to `tasks/ansible_user.yml`
- import `tasks/ansible_user.yml` in the main playbook
- normalize booleans and fold long cron command for lint compliance

## Testing
- `yamllint local.yml tasks/ansible_user.yml`
- `ansible-playbook --syntax-check local.yml`


------
https://chatgpt.com/codex/tasks/task_b_688e0351bd4c8333a6a276090229f580