### PR TITLE
refactor: consolidate GNOME tasks

### DIFF
--- a/tasks/gnome.yml
+++ b/tasks/gnome.yml
@@ -1,3 +1,12 @@
+---
+# GNOME configuration tasks
+#
+# Sections:
+#   1) Wallpaper
+#   2) Dconf settings
+#   3) GNOME Shell extensions
+
+# 1) Wallpaper
 - name: copy wallpaper file
   copy:
     src: files/abstract.jpg
@@ -7,50 +16,35 @@
 
 - name: set wallpaper
   become_user: lion
-  dconf:
+  community.general.dconf:
     key: "/org/gnome/desktop/background/picture-uri"
     value: "'file:///usr/share/backgrounds/abstract.jpg'"
 
 - name: set wallpaper in dark mode
   become_user: lion
-  dconf:
+  community.general.dconf:
     key: "/org/gnome/desktop/background/picture-uri-dark"
     value: "'file:///usr/share/backgrounds/abstract.jpg'"
 
 - name: set wallpaper position
   become_user: lion
-  dconf:
+  community.general.dconf:
     key: "/org/gnome/desktop/background/picture-options"
     value: "'zoom'"
 
-- name: set keyboard pref
-  become_user: lion
-  dconf:
-    key: "/org/gnome/desktop/input-sources"
-    value: "[('xkb', 'fr')]"
-
-- name: Configure Dash-to-Dock settings
+# 2) Dconf settings
+## Keyboard
+- name: Configure keyboard settings
   become_user: lion
   loop:
-    - { key: "/org/gnome/shell/extensions/dash-to-dock/background-opacity", value: "0.8" }
-    - { key: "/org/gnome/shell/extensions/dash-to-dock/dash-max-icon-size", value: "48" }
-    - { key: "/org/gnome/shell/extensions/dash-to-dock/dock-fixed", value: "false" }
-    - { key: "/org/gnome/shell/extensions/dash-to-dock/dock-position", value: "'BOTTOM'" }
-    - { key: "/org/gnome/shell/extensions/dash-to-dock/extend-height", value: "false" }
-    - { key: "/org/gnome/shell/extensions/dash-to-dock/height-fraction", value: "0.9" }
-    - { key: "/org/gnome/shell/extensions/dash-to-dock/isolate-workspaces", value: "true" }
-    - { key: "/org/gnome/shell/extensions/dash-to-dock/multi-monitor", value: "true" }
-    - { key: "/org/gnome/shell/extensions/dash-to-dock/preferred-monitor", value: "-2" }
-    - { key: "/org/gnome/shell/extensions/dash-to-dock/preferred-monitor-by-connector", value: "'DP-3'" }
-    - { key: "/org/gnome/shell/extensions/dash-to-dock/show-mounts", value: "false" }
-    - { key: "/org/gnome/shell/extensions/dash-to-dock/show-mounts-network", value: "false" }
-    - { key: "/org/gnome/shell/extensions/dash-to-dock/show-mounts-only-mounted", value: "true" }
+    - { key: "/org/gnome/desktop/input-sources", value: "[('xkb', 'fr')]" }
   loop_control:
     label: "{{ item.key }}"
   community.general.dconf:
     key: "{{ item.key }}"
     value: "{{ item.value }}"
 
+## Interface
 - name: Configure GNOME interface settings
   become_user: lion
   loop:
@@ -73,6 +67,7 @@
     key: "{{ item.key }}"
     value: "{{ item.value }}"
 
+## Peripherals, privacy, and screensaver
 - name: Configure GNOME peripherals, privacy, and screensaver settings
   become_user: lion
   loop:
@@ -101,64 +96,108 @@
     - { key: "/org/gnome/desktop/screensaver/picture-uri", value: "'file:///usr/share/backgrounds/abstract.jpg'" }
     - { key: "/org/gnome/desktop/screensaver/primary-color", value: "'#000000'" }
     - { key: "/org/gnome/desktop/screensaver/secondary-color", value: "'#000000'" }
-
-    # Search providers
-    - { key: "/org/gnome/desktop/search-providers/sort-order", value: "['org.gnome.Contacts.desktop', 'org.gnome.Documents.desktop', 'org.gnome.Nautilus.desktop', 'org.gnome.Settings.desktop', 'org.gnome.Characters.desktop', 'org.gnome.Calculator.desktop', 'org.gnome.Software.desktop', 'org.gnome.clocks.desktop', 'com.github.finefindus.eyedropper.desktop', 'org.gnome.seahorse.Application.desktop']" }
-
-    # Nautilus preferences
-    - { key: "/org/gnome/nautilus/preferences/default-folder-viewer", value: "'list-view'" }
-    - { key: "/org/gnome/nautilus/preferences/migrated-gtk-settings", value: "true" }
-    - { key: "/org/gnome/nautilus/preferences/recursive-search", value: "'always'" }
-    - { key: "/org/gnome/nautilus/preferences/search-filter-time-type", value: "'last_modified'" }
-    - { key: "/org/gnome/nautilus/preferences/search-view", value: "'list-view'" }
-    - { key: "/org/gnome/nautilus/preferences/show-directory-item-counts", value: "'always'" }
-
-    # Custom keyboard shortcuts
-    - { key: "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings", value: "['/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom2/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom3/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom4/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom5/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom6/']" }
-
-    - { key: "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0/name", value: "'Nautilus'" }
-    - { key: "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0/command", value: "'nautilus'" }
-    - { key: "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0/binding", value: "'<Super>e'" }
-
-    - { key: "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1/name", value: "'Terminal'" }
-    - { key: "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1/command", value: "'gnome-terminal'" }
-    - { key: "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1/binding", value: "'<Super>t'" }
-
-    - { key: "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom2/name", value: "'Char'" }
-    - { key: "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom2/command", value: "'/usr/bin/gnome-characters'" }
-    - { key: "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom2/binding", value: "'<Shift><Super>semicolon'" }
-
-    - { key: "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom3/name", value: "'Calc'" }
-    - { key: "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom3/command", value: "'gnome-calculator'" }
-    - { key: "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom3/binding", value: "'<Super>c'" }
-
-    - { key: "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom4/name", value: "'espanso restart'" }
-    - { key: "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom4/command", value: "'espanso restart'" }
-    - { key: "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom4/binding", value: "'<Shift><Super>twosuperior'" }
-
-    - { key: "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom5/name", value: "'screenshot print screen'" }
-    - { key: "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom5/command", value: "'script --command \"flameshot gui\" /dev/null'" }
-    - { key: "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom5/binding", value: "'Print'" }
-
-    - { key: "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom6/name", value: "'search (catsfish)'" }
-    - { key: "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom6/command", value: "'catfish'" }
-    - { key: "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom6/binding", value: "'<Super>space'" }
-
-    # Vitals extension settings
-    - { key: "/org/gnome/shell/extensions/vitals/hot-sensors", value: "['_memory_usage_', '_processor_usage_', '__network-rx_max__']" }
-    - { key: "/org/gnome/shell/extensions/vitals/icon-style", value: "1" }
-    - { key: "/org/gnome/shell/extensions/vitals/show-battery", value: "false" }
-    - { key: "/org/gnome/shell/extensions/vitals/storage-path", value: "'/home'" }
-
   loop_control:
     label: "{{ item.key }}"
   community.general.dconf:
     key: "{{ item.key }}"
     value: "{{ item.value }}"
 
-  ####################
-  # gnome extensions #
-  ####################
+## Search providers
+- name: Configure search providers
+  become_user: lion
+  loop:
+    - { key: "/org/gnome/desktop/search-providers/sort-order", value: "['org.gnome.Contacts.desktop', 'org.gnome.Documents.desktop', 'org.gnome.Nautilus.desktop', 'org.gnome.Settings.desktop', 'org.gnome.Characters.desktop', 'org.gnome.Calculator.desktop', 'org.gnome.Software.desktop', 'org.gnome.clocks.desktop', 'com.github.finefindus.eyedropper.desktop', 'org.gnome.seahorse.Application.desktop']" }
+  loop_control:
+    label: "{{ item.key }}"
+  community.general.dconf:
+    key: "{{ item.key }}"
+    value: "{{ item.value }}"
+
+## Nautilus preferences
+- name: Configure Nautilus preferences
+  become_user: lion
+  loop:
+    - { key: "/org/gnome/nautilus/preferences/default-folder-viewer", value: "'list-view'" }
+    - { key: "/org/gnome/nautilus/preferences/migrated-gtk-settings", value: "true" }
+    - { key: "/org/gnome/nautilus/preferences/recursive-search", value: "'always'" }
+    - { key: "/org/gnome/nautilus/preferences/search-filter-time-type", value: "'last_modified'" }
+    - { key: "/org/gnome/nautilus/preferences/search-view", value: "'list-view'" }
+    - { key: "/org/gnome/nautilus/preferences/show-directory-item-counts", value: "'always'" }
+  loop_control:
+    label: "{{ item.key }}"
+  community.general.dconf:
+    key: "{{ item.key }}"
+    value: "{{ item.value }}"
+
+## Custom keyboard shortcuts
+- name: Configure custom keyboard shortcuts
+  become_user: lion
+  loop:
+    - { key: "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings", value: "['/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom2/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom3/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom4/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom5/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom6/']" }
+    - { key: "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0/name", value: "'Nautilus'" }
+    - { key: "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0/command", value: "'nautilus'" }
+    - { key: "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0/binding", value: "'<Super>e'" }
+    - { key: "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1/name", value: "'Terminal'" }
+    - { key: "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1/command", value: "'gnome-terminal'" }
+    - { key: "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1/binding", value: "'<Super>t'" }
+    - { key: "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom2/name", value: "'Char'" }
+    - { key: "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom2/command", value: "'/usr/bin/gnome-characters'" }
+    - { key: "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom2/binding", value: "'<Shift><Super>semicolon'" }
+    - { key: "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom3/name", value: "'Calc'" }
+    - { key: "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom3/command", value: "'gnome-calculator'" }
+    - { key: "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom3/binding", value: "'<Super>c'" }
+    - { key: "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom4/name", value: "'espanso restart'" }
+    - { key: "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom4/command", value: "'espanso restart'" }
+    - { key: "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom4/binding", value: "'<Shift><Super>twosuperior'" }
+    - { key: "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom5/name", value: "'screenshot print screen'" }
+    - { key: "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom5/command", value: "'script --command \"flameshot gui\" /dev/null'" }
+    - { key: "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom5/binding", value: "'Print'" }
+    - { key: "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom6/name", value: "'search (catsfish)'" }
+    - { key: "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom6/command", value: "'catfish'" }
+    - { key: "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom6/binding", value: "'<Super>space'" }
+  loop_control:
+    label: "{{ item.key }}"
+  community.general.dconf:
+    key: "{{ item.key }}"
+    value: "{{ item.value }}"
+
+# 3) GNOME Shell extensions
+## Dash-to-Dock
+- name: Configure Dash-to-Dock settings
+  become_user: lion
+  loop:
+    - { key: "/org/gnome/shell/extensions/dash-to-dock/background-opacity", value: "0.8" }
+    - { key: "/org/gnome/shell/extensions/dash-to-dock/dash-max-icon-size", value: "48" }
+    - { key: "/org/gnome/shell/extensions/dash-to-dock/dock-fixed", value: "false" }
+    - { key: "/org/gnome/shell/extensions/dash-to-dock/dock-position", value: "'BOTTOM'" }
+    - { key: "/org/gnome/shell/extensions/dash-to-dock/extend-height", value: "false" }
+    - { key: "/org/gnome/shell/extensions/dash-to-dock/height-fraction", value: "0.9" }
+    - { key: "/org/gnome/shell/extensions/dash-to-dock/isolate-workspaces", value: "true" }
+    - { key: "/org/gnome/shell/extensions/dash-to-dock/multi-monitor", value: "true" }
+    - { key: "/org/gnome/shell/extensions/dash-to-dock/preferred-monitor", value: "-2" }
+    - { key: "/org/gnome/shell/extensions/dash-to-dock/preferred-monitor-by-connector", value: "'DP-3'" }
+    - { key: "/org/gnome/shell/extensions/dash-to-dock/show-mounts", value: "false" }
+    - { key: "/org/gnome/shell/extensions/dash-to-dock/show-mounts-network", value: "false" }
+    - { key: "/org/gnome/shell/extensions/dash-to-dock/show-mounts-only-mounted", value: "true" }
+  loop_control:
+    label: "{{ item.key }}"
+  community.general.dconf:
+    key: "{{ item.key }}"
+    value: "{{ item.value }}"
+
+## Vitals
+- name: Configure Vitals extension settings
+  become_user: lion
+  loop:
+    - { key: "/org/gnome/shell/extensions/vitals/hot-sensors", value: "['_memory_usage_', '_processor_usage_', '__network-rx_max__']" }
+    - { key: "/org/gnome/shell/extensions/vitals/icon-style", value: "1" }
+    - { key: "/org/gnome/shell/extensions/vitals/show-battery", value: "false" }
+    - { key: "/org/gnome/shell/extensions/vitals/storage-path", value: "'/home'" }
+  loop_control:
+    label: "{{ item.key }}"
+  community.general.dconf:
+    key: "{{ item.key }}"
+    value: "{{ item.value }}"
 
 #- name: install extensions
 #  become: true
@@ -170,10 +209,6 @@
 
 #- name: Enable gnome extensions
 #  become_user: lion
-#  dconf:
+#  community.general.dconf:
 #    key: "/org/gnome/shell/enabled-extensions"
-#    value: "['Vitals@CoreCoding.com' ]" #gsconnect@andyholmes.github.io', 'clipboard-history@alexsaveau.dev'
-
-  ####################
-  # the rest         # 
-  ####################
+#    value: "['Vitals@CoreCoding.com']"  # gsconnect@andyholmes.github.io, clipboard-history@alexsaveau.dev


### PR DESCRIPTION
## Summary
- merge GNOME wallpaper, dconf, and extension configuration into a single organized task file
- import the consolidated GNOME task file directly in the main playbook

## Testing
- `ansible-playbook local.yml --syntax-check`


------
https://chatgpt.com/codex/tasks/task_b_688e0cb50af48333babe42fc8b41b147