### PR TITLE
Add tasks to install Nerd, Google, and additional fonts

### DIFF
--- a/local.yml
+++ b/local.yml
@@ -12,6 +12,7 @@
   tasks:
   - import_tasks: tasks/gnome.yml
   - import_tasks: tasks/packages.yml
+  - import_tasks: tasks/fonts.yml
   - import_tasks: tasks/bashrc.yml
   - import_tasks: tasks/ansible_sudo_user.yml
 

--- a/tasks/fonts.yml
+++ b/tasks/fonts.yml
@@ -1,0 +1,36 @@
+- name: Ensure system fonts directory exists
+  ansible.builtin.file:
+    path: /usr/local/share/fonts
+    state: directory
+    mode: "0755"
+
+- name: Install FiraCode Nerd Font
+  ansible.builtin.unarchive:
+    src: https://github.com/ryanoasis/nerd-fonts/releases/latest/download/FiraCode.zip
+    dest: /usr/local/share/fonts
+    remote_src: true
+    creates: "/usr/local/share/fonts/Fira Code Regular Nerd Font Complete.ttf"
+
+- name: Install Roboto font from Google Fonts
+  ansible.builtin.unarchive:
+    src: https://fonts.google.com/download?family=Roboto
+    dest: /usr/local/share/fonts/roboto
+    remote_src: true
+    creates: /usr/local/share/fonts/roboto/Roboto-Regular.ttf
+
+- name: Install Century Gothic font
+  ansible.builtin.get_url:
+    url: https://github.com/hggh/century-gothic/raw/master/CenturyGothic.ttf
+    dest: /usr/local/share/fonts/CenturyGothic.ttf
+    mode: "0644"
+
+- name: Install Manrope font from Google Fonts
+  ansible.builtin.unarchive:
+    src: https://fonts.google.com/download?family=Manrope
+    dest: /usr/local/share/fonts/manrope
+    remote_src: true
+    creates: /usr/local/share/fonts/manrope/Manrope-Regular.ttf
+
+- name: Refresh font cache
+  ansible.builtin.command: fc-cache -f -v
+  changed_when: false


### PR DESCRIPTION
## Summary
- add playbook tasks to download and install Nerd Font, Roboto, Century Gothic, and Manrope fonts
- wire fonts tasks into main local playbook

## Testing
- `ansible-playbook --syntax-check local.yml`


------
https://chatgpt.com/codex/tasks/task_b_6891bcf7d6a08333b9f619d94cf4723e