### PR TITLE
Skip redundant downloads in tasks

### DIFF
--- a/roles/server/tasks/stirling_pdf.yml
+++ b/roles/server/tasks/stirling_pdf.yml
@@ -13,12 +13,20 @@
     enabled: yes
   become: yes
 
+- name: Check if Stirling PDF container exists
+  community.docker.docker_container_info:
+    name: stirling-pdf
+  register: stirling_pdf_info
+  failed_when: false
+  become: yes
+
 - name: Pull frooodle/s-pdf image
   community.docker.docker_image:
     name: frooodle/s-pdf
     tag: latest
     source: pull
   become: yes
+  when: stirling_pdf_info.container is not defined
 
 - name: Run Stirling PDF container
   community.docker.docker_container:
@@ -35,3 +43,4 @@
     env:
       DOCKER_ENABLE_SECURITY: "false"
   become: yes
+  when: stirling_pdf_info.container is not defined

--- a/tasks/fonts.yml
+++ b/tasks/fonts.yml
@@ -24,11 +24,17 @@
     remote_src: true
     creates: /usr/share/fonts/roboto/Roboto-Regular.ttf
 
+- name: Check if Manrope font is installed
+  ansible.builtin.stat:
+    path: /usr/share/fonts/Manrope-Regular.ttf
+  register: manrope_font
+
 - name: Install Manrope font from Google Fonts
   ansible.builtin.get_url:
     url: https://github.com/davelab6/manrope/raw/master/ttf%20format%20(legacy)/manrope-regular.ttf
     dest: /usr/share/fonts/Manrope-Regular.ttf
     mode: "0644"
+  when: not manrope_font.stat.exists
 
 - name: Refresh font cache
   ansible.builtin.command: fc-cache -f -v

--- a/tasks/micro_config.yml
+++ b/tasks/micro_config.yml
@@ -7,9 +7,16 @@
     state: directory
     mode: '0755'
 
+- name: Check if search.lua plugin is present
+  become_user: "{{ desktop_user }}"
+  ansible.builtin.stat:
+    path: "{{ desktop_home }}/.config/micro/plug/search/search.lua"
+  register: micro_search_plugin
+
 - name: Download search.lua plugin
   become_user: "{{ desktop_user }}"
   ansible.builtin.get_url:
     url: "https://raw.githubusercontent.com/dmaluka/micro-search/master/search.lua"
     dest: "{{ desktop_home }}/.config/micro/plug/search/search.lua"
     mode: '0644'
+  when: not micro_search_plugin.stat.exists

--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -87,34 +87,63 @@
 
 # AM-application-manager
 
+- name: Check if AM is installed
+  ansible.builtin.stat:
+    path: /usr/local/bin/am
+  register: am_binary
+
 - name: Download AM-application-manager INSTALL script
   ansible.builtin.get_url:
     url: https://raw.githubusercontent.com/ivan-hc/AM/main/INSTALL
     dest: /tmp/AM_INSTALL
     mode: '0755'
+  when: not am_binary.stat.exists
 
 - name: Run AM-application-manager INSTALL script
   ansible.builtin.command: /tmp/AM_INSTALL
   become: yes
+  when: not am_binary.stat.exists
 
 - name: Remove AM-application-manager INSTALL script
   ansible.builtin.file:
     path: /tmp/AM_INSTALL
     state: absent
   become: yes
+  when: not am_binary.stat.exists
 
-- name: Install Beeper and OrcaSlicer AppImages using AM (auto-confirm prompts)
+- name: List installed AM packages
   become_user: "{{ desktop_user }}"
-  ansible.builtin.shell: |
-    yes | am -i beeper
-    yes | am -i orcaslicer-any
+  ansible.builtin.command: am -l
+  register: am_list
+  changed_when: false
+  failed_when: false
+  when: am_binary.stat.exists
+
+- name: Install Beeper AppImage using AM (auto-confirm prompt)
+  become_user: "{{ desktop_user }}"
+  ansible.builtin.shell: yes | am -i beeper
   args:
     executable: /bin/bash
   environment:
     PATH: "/usr/local/bin:{{ ansible_env.PATH }}"
+  when:
+    - am_binary.stat.exists
+    - "'beeper' not in am_list.stdout"
+
+- name: Install OrcaSlicer AppImage using AM (auto-confirm prompt)
+  become_user: "{{ desktop_user }}"
+  ansible.builtin.shell: yes | am -i orcaslicer-any
+  args:
+    executable: /bin/bash
+  environment:
+    PATH: "/usr/local/bin:{{ ansible_env.PATH }}"
+  when:
+    - am_binary.stat.exists
+    - "'orcaslicer-any' not in am_list.stdout"
 
 - name: Update AppImages with AM
   become_user: "{{ desktop_user }}"
   ansible.builtin.shell: am -u
   environment:
     PATH: "/usr/local/bin:{{ ansible_env.PATH }}"
+  when: am_binary.stat.exists

--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -119,6 +119,14 @@
   failed_when: false
   when: am_binary.stat.exists
 
+- name: Debug AM package list
+  ansible.builtin.debug:
+    msg:
+      - "am_list.rc: {{ am_list.rc | default('undefined') }}"
+      - "am_list.stdout: {{ am_list.stdout | default('undefined') }}"
+      - "am_list.stderr: {{ am_list.stderr | default('undefined') }}"
+  when: am_binary.stat.exists
+
 - name: Install Beeper AppImage using AM (auto-confirm prompt)
   become_user: "{{ desktop_user }}"
   ansible.builtin.shell: yes | am -i beeper
@@ -128,7 +136,7 @@
     PATH: "/usr/local/bin:{{ ansible_env.PATH }}"
   when:
     - am_binary.stat.exists
-    - "'beeper' not in am_list.stdout"
+    - "'beeper' not in (am_list.stdout | default(''))"
 
 - name: Install OrcaSlicer AppImage using AM (auto-confirm prompt)
   become_user: "{{ desktop_user }}"
@@ -139,7 +147,7 @@
     PATH: "/usr/local/bin:{{ ansible_env.PATH }}"
   when:
     - am_binary.stat.exists
-    - "'orcaslicer-any' not in am_list.stdout"
+    - "'orcaslicer-any' not in (am_list.stdout | default(''))"
 
 - name: Update AppImages with AM
   become_user: "{{ desktop_user }}"


### PR DESCRIPTION
## Summary
- avoid Manrope font download when already installed
- guard micro search plugin download with stat check
- skip AM application manager setup and AppImage installs if already present
- run Stirling PDF container only when missing

## Testing
- `ansible-playbook --syntax-check local.yml`
- `yamllint tasks/fonts.yml tasks/micro_config.yml tasks/packages.yml roles/server/tasks/stirling_pdf.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6895d75d5b1883338d5478c60184697a